### PR TITLE
Added support for Test Suites

### DIFF
--- a/src/main/kotlin/io/cloudflight/license/gradle/tracker/task/CreateTrackerReportTask.kt
+++ b/src/main/kotlin/io/cloudflight/license/gradle/tracker/task/CreateTrackerReportTask.kt
@@ -11,19 +11,25 @@ import io.cloudflight.license.gradle.npm.NpmLicenseParser
 import io.cloudflight.license.gradle.tracker.model.npm.NpmPackageParser
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.attributes.Category
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JvmTestSuitePlugin
+import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.testing.base.TestingExtension
 import java.io.File
 
 abstract class CreateTrackerReportTask : DefaultTask() {
@@ -71,6 +77,12 @@ abstract class CreateTrackerReportTask : DefaultTask() {
         report.provided = collectDependencies(project.configurations, JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
         report.test = collectDependencies(project.configurations, JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
 
+        project.configurations.names.filter { it.lowercase().endsWith(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME.lowercase())
+                && it != JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME && it != JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME }
+            .forEach { namedTestSuite ->
+                report.test += collectDependencies(project.configurations, namedTestSuite)
+            }
+
         val developmentArtifacts = mutableListOf<Artifact>()
         developmentArtifacts.addAll(
             collectDependencies(project.configurations, JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME) +
@@ -107,7 +119,7 @@ abstract class CreateTrackerReportTask : DefaultTask() {
         val packageJson = getPackageJson()
         val packageLockJson = getPackageLockJson()
 
-        if (packageJson.isPresent && packageJson.get().asFile.exists() && packageLockJson.isPresent && packageJson.get().asFile.exists()) {
+        if (packageJson.isPresent && packageJson.get().asFile.exists() && packageLockJson.isPresent && packageLockJson.get().asFile.exists()) {
             try {
                 val parser = NpmPackageParser()
                 val npmModuleDependencies =

--- a/src/main/kotlin/io/cloudflight/license/gradle/tracker/task/CreateTrackerReportTask.kt
+++ b/src/main/kotlin/io/cloudflight/license/gradle/tracker/task/CreateTrackerReportTask.kt
@@ -11,25 +11,19 @@ import io.cloudflight.license.gradle.npm.NpmLicenseParser
 import io.cloudflight.license.gradle.tracker.model.npm.NpmPackageParser
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
-import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.attributes.Category
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.JvmTestSuitePlugin
-import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.testing.base.TestingExtension
 import java.io.File
 
 abstract class CreateTrackerReportTask : DefaultTask() {

--- a/src/test/fixtures/single-suite-module/build.gradle
+++ b/src/test/fixtures/single-suite-module/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'io.cloudflight.license-gradle-plugin'
+    id 'jvm-test-suite'
+}
+
+description "Cloudflight Gradle Test"
+group "io.cloudflight.gradle"
+version "1.0.0"
+
+plugins.forEach {
+    logger.quiet("Plugin {} applied", it.class.name)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'io.cloudflight.json:json-wrapper:0.3.3'
+}
+
+testing {
+    suites {
+        testContainer(JvmTestSuite) {
+            dependencies {
+                implementation 'org.assertj:assertj-core:3.21.0'
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn(testing.suites.testContainer)
+}

--- a/src/test/fixtures/single-suite-module/settings.gradle
+++ b/src/test/fixtures/single-suite-module/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'single-suite-module'

--- a/src/test/fixtures/single-suite-module/src/main/java/io/cloudflight/gradle/Foo.java
+++ b/src/test/fixtures/single-suite-module/src/main/java/io/cloudflight/gradle/Foo.java
@@ -1,0 +1,4 @@
+package io.cloudflight.gradle;
+
+public class Foo {
+}

--- a/src/test/fixtures/single-suite-module/src/test/java/io/cloudflight/gradle/FooTest.java
+++ b/src/test/fixtures/single-suite-module/src/test/java/io/cloudflight/gradle/FooTest.java
@@ -1,0 +1,9 @@
+
+import org.junit.jupiter.api.Test;
+
+public class FooTest {
+    @Test
+    public void test() {
+
+    }
+}

--- a/src/test/kotlin/io/cloudflight/license/gradle/LicensePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/license/gradle/LicensePluginTest.kt
@@ -122,6 +122,21 @@ class LicensePluginTest {
             assertThat(dependencies.development.find { it.artifact.contains("@colors:colors") }).isNotNull
             assertThat(dependencies.development.find { it.artifact.contains("@npm:fsevents") }).isNull()
         }
+
+    @Test
+    fun `test-suite dependencies are collected correctly`(): Unit =
+        licenseFixture("single-suite-module") {
+            val result = run("clean", "clfCreateTrackerReport")
+            println(result.normalizedOutput)
+            assertThat(result.normalizedOutput).doesNotContain("license can't be parsed")
+            assertThat(result.task(":clfLicenseReport")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(result.task(":clfCreateTrackerReport")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+            val dependencies =
+                Report.readFromFile(fixtureDir.resolve("build/tracker/dependencies.json").toFile())
+            assertThat(dependencies.test.find { it.artifact.contains("org.assertj:assertj-core") }).isNotNull
+            assertThat(dependencies.test.find { it.artifact.contains("io.cloudflight.json:json-wrapper") }).isNotNull
+        }
 }
 
 


### PR DESCRIPTION
Because test suites can have customized names, the JavaPlugin only considers the suite named "test".  
Other names for suites are now also considered by checking all found configurations.